### PR TITLE
fixed incorrect exception reference and corrected access_token/id refer…

### DIFF
--- a/src/AuthenticationPostListener.php
+++ b/src/AuthenticationPostListener.php
@@ -6,7 +6,7 @@ use Interop\Container\ContainerInterface;
 use ZF\MvcAuth\MvcAuthEvent;
 use ZF\MvcAuth\Identity\AuthenticatedIdentity as MvcAuthAuthenticatedIdentity;
 use ZF\OAuth2\Doctrine\Identity\AuthenticatedIdentity as DoctrineAuthenticatedIdentity;
-use ZF\OAuth2\Doctrine\Identity\Exception;
+use ZF\OAuth2\Doctrine\Identity\AccessTokenException;
 use GianArb\Angry\Unclonable;
 use GianArb\Angry\Unserializable;
 
@@ -32,7 +32,7 @@ class AuthenticationPostListener
 
         $accessToken = $this->findAccessToken($identity->getAuthenticationIdentity());
         if (!$accessToken) {
-            throw new Exception\AccessTokenException('Access Token expected for authenticated identity not found');
+            throw new AccessTokenException('Access Token expected for authenticated identity not found');
         }
 
         $doctrineAuthenticatedIdentity = new DoctrineAuthenticatedIdentity($accessToken, $mvcAuthEvent->getAuthorizationService());
@@ -52,7 +52,7 @@ class AuthenticationPostListener
 
                 $accessToken = $accessTokenRepository->findOneBy([
                     $oauth2Config['mapping']['AccessToken']['mapping']['access_token']['name']
-                    => $identity['access_token'],
+                    => array_key_exists('access_token', $identity) ? $identity['access_token'] : $identity['id'],
                 ]);
 
                 if ($accessToken) {


### PR DESCRIPTION
…ene from identity

1 - The AccessTokenException class was incorrectly referenced.
2 - When enabling JWT access tokens (in conjunction with bshaffer/oauth2-server-php), the $identity['access_token'] does not exist. Rather, $identity['id'] can be used so long as the following two configs have been set:

- use_jwt_access_tokens: true
- store_encrypted_token_string: false

Without the change in #2 above, JWT access tokens cannot be used.
